### PR TITLE
Docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:65f1c4bea0b2
+FROM jupyter/datascience-notebook:b7f28609e908
 
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   environment:
-    DOCKER_IMAGE_NAME: quay.io/mojanalytics/jupyter
+    DOCKER_IMAGE_NAME: quay.io/mojanalytics/datascience-notebook
     DOCKER_IMAGE_TAG: $(echo $CIRCLE_SHA1 | cut -c -8)
 
 test:


### PR DESCRIPTION
Upgrade Base Image
    
Clair on quay.io still complains but the image appears to work

--------------
Image Tag
    
Other Jupyter notebooks are in the pipeline to be deployed to the platform.
    
Changing for clarity.
