### PR TITLE
User Package Path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
 USER root
 
+ENV PATH=$PATH:$HOME/.local/bin
+
 ENV NB_UID=1001

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It adds Anaconda and Jupyter dashboard.
 ### Disabling authentication
 In order to disable the authentication you can run this container as follows:
 
-    $ docker run -d -p 8888:8888 jupyter/datascience-notebook start-notebook.sh --NotebookApp.token=''
+    $ docker container run -d --rm -p 8888:8888 jupyter/datascience-notebook start-notebook.sh --NotebookApp.token=''
     
 ### Known issues
  - This image is a work in progress, you'll currently get a "Dead kernel" error in Jupyter notebook ([this issue may be related](https://github.com/jupyter/docker-stacks/issues/337))


### PR DESCRIPTION
Users by default will install packages to their `$HOME` shares.

See: https://trello.com/c/NKz0zS0m

Adding `.local/bin` dir to path

Updated run the command in README to reflect best practice and avoid
confusion for future deprecations.