### PR TITLE
DataScience Notebook base upgrade

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:b7f28609e908
+FROM jupyter/datascience-notebook:265297f221de
 
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 


### PR DESCRIPTION
[Trello](https://trello.com/c/M1snktNZ)

Troubleshooting websocket closures, where Jupyter's UI becomes completely
unresponsive everytime a websocket loses connection.

Current Versions:
- NoteBook: 5.2.2
- Tornado: 4.5.3 (library handling connections)

Upgraded Versions:
- NoteBook: 5.6.0
- Tornado: 5.1