### PR TITLE
All-Spark notebook upgrade

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/all-spark-notebook:cf57ef145dce
+FROM jupyter/all-spark-notebook:265297f221de
 
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 


### PR DESCRIPTION
[Trello](https://trello.com/c/N14xFzoi)

Troubleshooting websocket closures, where Jupyter's UI becomes completely
unresponsive everytime a websocket loses connection.

Current Versions:
- NoteBook: 5.2.2
- Tornado: 4.5.3 (library handling connections)

Upgraded Versions:
- NoteBook: 5.6.0
- Tornado: 5.1