### PR TITLE
Update spark config so that users can read data from s3

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -7,6 +7,8 @@ USER root
 ENV PATH=$PATH:$HOME/.local/bin
 ENV NB_UID=1001
 
+ENV PYSPARK_SUBMIT_ARGS="--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.1 pyspark-shell"
+
 COPY ./files/* /tmp/
 RUN conda install boto3 \
     && python /tmp/pyspark-s3.py \

--- a/files/hdfs-site.xml
+++ b/files/hdfs-site.xml
@@ -1,6 +1,6 @@
 <configuration>
     <property>
-        <name>fs.s3.impl</name>
-        <value>org.apache.hadoop.fs.s3native.NativeS3FileSystem</value>
+        <name>fs.s3a.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
     </property>
 </configuration>

--- a/files/pyspark-s3.py
+++ b/files/pyspark-s3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-os.environ['PYSPARK_SUBMIT_ARGS'] = '--packages com.amazonaws:aws-java-sdk:1.10.34,org.apache.hadoop:hadoop-aws:2.6.0 pyspark-shell'
+os.environ['PYSPARK_SUBMIT_ARGS'] = '--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.1 pyspark-shell'
 
 import pyspark
 sc = pyspark.SparkContext("local[*]")
@@ -10,4 +10,4 @@ from pyspark.sql import SQLContext
 sqlContext = SQLContext(sc)
 
 hadoopConf = sc._jsc.hadoopConfiguration()
-hadoopConf.set("fs.s3.impl", "org.apache.hadoop.fs.s3native.NativeS3FileSystem")
+hadoopConf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")


### PR DESCRIPTION
See [here](https://stackoverflow.com/a/52791250/1779128) for some further information about these configuration changes.

Users can now write much simpler code to use spark with s3, e.g.

```
from pyspark import SparkContext
sc = SparkContext.getOrCreate()
spark = SparkSession(sc)
df = spark.read.parquet("s3a://mybucket/iris_parquet/")
df.show(5)
```
