### PR TITLE
Remove NB_UID ENV command

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -5,7 +5,6 @@ LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 USER root
 
 ENV PATH=$PATH:$HOME/.local/bin
-ENV NB_UID=1001
 
 ENV PYSPARK_SUBMIT_ARGS="--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.1 pyspark-shell"
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -6,8 +6,6 @@ USER root
 
 ENV PATH=$PATH:$HOME/.local/bin
 
-ENV NB_UID=1001
-
 COPY ./files/apt_packages /tmp/
 
 RUN conda install boto3 \


### PR DESCRIPTION
The NB_UID environment variable doesn't need to be set anymore as we are
handling the UID for the running user in the corresponding helm chart now. This
is better because setting the NB_UID in the docker file causes the upstream
image to `chown` the home directory to this uid, but this is slow and gets
slower as the users have more files in their home directory.

We are now making the cluster launch the pod with the running user as 1001 so
this chown is not required