### PR TITLE
Different approach to speeding up startup

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 USER root
 
 ENV PATH=$PATH:$HOME/.local/bin
+ENV NB_UID=1001
+ENV CHOWN_HOME=no
 
 ENV PYSPARK_SUBMIT_ARGS="--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.1 pyspark-shell"
 

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 USER root
 
 ENV PATH=$PATH:$HOME/.local/bin
+ENV NB_UID=1001
+ENV CHOWN_HOME=no
 
 COPY ./files/apt_packages /tmp/
 


### PR DESCRIPTION
Previously we removed the NB_UID from the environment so that the ./start.sh
script didn't have to CHOWN the home directory. This worked but broke a couple
of things like the ability to SUDO and also pypark's java runtime.

I've added NB_UID back but set another environment variable called CHOWN_HOME
that stops the ./start.sh from having to do the chown on the home directory.