### PR TITLE
Fix Conda permissions

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -18,3 +18,5 @@ RUN conda install boto3 \
     && pip install git+https://github.com/moj-analytical-services/gluejobutils/#egg=gluejobutils \
     && mv /tmp/hdfs-site.xml /usr/local/spark/conf \
     && apt-get update && apt-get install -y $(cat /tmp/apt_packages)
+
+RUN chown -R $NB_UID /opt/conda

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -12,3 +12,6 @@ COPY ./files/apt_packages /tmp/
 
 RUN conda install boto3 \
     && apt-get update && apt-get install -y $(cat /tmp/apt_packages)
+
+# Fix conda install for NB_UID
+RUN chown -R $NB_UID /opt/conda


### PR DESCRIPTION
The base image does a chown -R on /opt/conda for the default uid 1000 but since
we run as UID 1001 we need to re-chown the conda directory.

Conda is broken at the moment so users aren't using it, but once this is turned
on `conda install` will install packages to `/opt/conda/pkgs/` which will get
wiped on reboot so maybe we need to do something similar to the pipcorn alias
that makes packages install to ~/local/

## How to test
1. In your jupyter terminal try to `conda install something`
    It will fail with a permissions error.
2. Update your deployment to point to the image for this branch
3. In your jupyter terminal try to `conda install something`
    Conda should install it successfully 