### PR TITLE
Stop Slow Startup

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -18,5 +18,7 @@ RUN conda install boto3 \
     && pip install git+https://github.com/moj-analytical-services/gluejobutils/#egg=gluejobutils \
     && mv /tmp/hdfs-site.xml /usr/local/spark/conf \
     && apt-get update && apt-get install -y $(cat /tmp/apt_packages)
+    && rm -rf  /var/lib/apt/lists/*
 
-RUN chown -R $NB_UID /opt/conda
+RUN chown -R $NB_UID /opt/conda \
+  && usermod -u $NB_UID $NB_USER

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -11,7 +11,10 @@ ENV CHOWN_HOME=no
 COPY ./files/apt_packages /tmp/
 
 RUN conda install boto3 \
-    && apt-get update && apt-get install -y $(cat /tmp/apt_packages)
+    && apt-get update \
+    && apt-get install -y $(cat /tmp/apt_packages) \
+    && rm -rf /var/lib/apt/lists/*
 
 # Fix conda install for NB_UID
-RUN chown -R $NB_UID /opt/conda
+RUN chown -R $NB_UID /opt/conda \
+ &&usermod -u $NB_UID $NB_USER


### PR DESCRIPTION
The `start.sh` runs `usermod -u` before launching jupyter lab. This means that
it will also chown the user's home directory. This makes startup really slow if
softnas is running slowly or is in another AZ from the user's node.

This change makes the usermod happen before the NFS volume is mounted so it will
only need to STAT / CHOWN a small number of files.