### PR TITLE
Bugfix for the all-spark Dockerfile

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -17,7 +17,7 @@ RUN conda install boto3 \
     && pip install git+https://github.com/moj-analytical-services/dataengineeringutils.git \
     && pip install git+https://github.com/moj-analytical-services/gluejobutils/#egg=gluejobutils \
     && mv /tmp/hdfs-site.xml /usr/local/spark/conf \
-    && apt-get update && apt-get install -y $(cat /tmp/apt_packages)
+    && apt-get update && apt-get install -y $(cat /tmp/apt_packages) \
     && rm -rf  /var/lib/apt/lists/*
 
 RUN chown -R $NB_UID /opt/conda \


### PR DESCRIPTION
Was trying to use the all-spark notebook but realised the version I wanted
wasn't on quay. Checked build and it turns out I forgot a `\` in my last commit.

This fixes the issue so the Dockerfile can build