### PR TITLE
(WIP) Updated spark image to spark 2.4 to bring in line with AWS Glue

### DIFF
--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/all-spark-notebook@sha256:ae9cc8bfa83b41162369cd40fde65afa315ef7777f29c1e8bc8535d1396b621a
+FROM jupyter/all-spark-notebook@sha256:1e31465c2dccb82ae249a31ba5412cf25388a12a9b949c76381842dd76b46efd
 
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
@@ -18,4 +18,4 @@ RUN conda install boto3 \
     && rm -rf  /var/lib/apt/lists/*
 
 RUN chown -R $NB_UID /opt/conda \
-  && usermod -u $NB_UID $NB_USER
+    && usermod -u $NB_UID $NB_USER

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/all-spark-notebook@sha256:1c10f355f0272b4e398bba1d8012907d02084f12ed78054458075d3990a2ecb1
+FROM jupyter/all-spark-notebook@sha256:ae9cc8bfa83b41162369cd40fde65afa315ef7777f29c1e8bc8535d1396b621a
 
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
@@ -19,5 +19,3 @@ RUN conda install boto3 \
 
 RUN chown -R $NB_UID /opt/conda \
   && usermod -u $NB_UID $NB_USER
-
-

--- a/all-spark-notebook/Dockerfile
+++ b/all-spark-notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/all-spark-notebook:1145fb1198b2
+FROM jupyter/all-spark-notebook@sha256:1c10f355f0272b4e398bba1d8012907d02084f12ed78054458075d3990a2ecb1
 
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
@@ -13,12 +13,11 @@ ENV PYSPARK_SUBMIT_ARGS="--packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.
 COPY ./files/* /tmp/
 RUN conda install boto3 \
     && python /tmp/pyspark-s3.py \
-    && pip install git+https://github.com/moj-analytical-services/etl_manager.git#egg=etl_manager \
-    && pip install git+https://github.com/moj-analytical-services/dataengineeringutils.git \
-    && pip install git+https://github.com/moj-analytical-services/gluejobutils/#egg=gluejobutils \
     && mv /tmp/hdfs-site.xml /usr/local/spark/conf \
     && apt-get update && apt-get install -y $(cat /tmp/apt_packages) \
     && rm -rf  /var/lib/apt/lists/*
 
 RUN chown -R $NB_UID /opt/conda \
   && usermod -u $NB_UID $NB_USER
+
+


### PR DESCRIPTION
For reasons unknown this currently fails with:

```
(base) ➜  analytics-platform-jupyter-notebook git:(spark_24) kubectl logs jupyter-lab-robinl-jupyt-75579f9c54-7pwrx jupyter-lab
Set username to: jovyan
usermod: no changes
Executing the command: jupyter lab --NotebookApp.token=''
sudo: jupyter lab: command not found
```

Possibly related to:
https://github.com/jupyter/docker-stacks/issues/524