### PR TITLE
Fix extension installation directory

### DIFF
--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -22,6 +22,14 @@ RUN pip install --upgrade \
         s3fs
 
 RUN npm install jupyterlab-flake8
-RUN jupyter labextension install jupyterlab-flake8 \
-        && jupyter labextension install @ryantam626/jupyterlab_code_formatter \
-        && jupyter serverextension enable --py jupyterlab_code_formatter
+
+ENV JUPYTERLAB_DIR="/home/jovyan/.jupyter"
+RUN jupyter labextension install \
+        jupyterlab-flake8 \
+        @jupyter-widgets/jupyterlab-manager \
+        @jupyterlab/github \
+        @jupyterlab/git \
+        @ryantam626/jupyterlab_code_formatter
+
+RUN jupyter serverextension enable --py \
+        jupyterlab_code_formatter

--- a/datascience-notebook/docker-compose.yml
+++ b/datascience-notebook/docker-compose.yml
@@ -4,3 +4,11 @@ version: "3.7"
 services:
   test:
     image: mojanalytics/datascience-notebook:latest
+    # image: quay.io/mojanalytics/datascience-notebook:v0.6.9
+    command:
+      - "/usr/local/bin/start-notebook.sh"
+      - "--NotebookApp.token=''"
+    ports:
+      - 8888:8888
+    environment:
+      - JUPYTER_ENABLE_LAB=true


### PR DESCRIPTION
This gives users the ability to install extensions into a directory they
own.

- Installs & enables a small number of extensions by default
- Enable docker-compose port forwarding for local testing