### PR TITLE
[Testing] Stop installing InSpec in the pipeline

### DIFF
--- a/.github/workflows/allspark-notebook.yml
+++ b/.github/workflows/allspark-notebook.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Build
         run: make build
         working-directory: ${{env.working-directory}}
-      - name: Install Inspec
-        uses: actionshub/chef-install@1.1.0
-        with: { project: inspec }
       - name: Test
         run: make test
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/datascience-notebook.yml
+++ b/.github/workflows/datascience-notebook.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Build
         run: make build
         working-directory: ${{env.working-directory}}
-      - name: Install Inspec
-        uses: actionshub/chef-install@1.1.0
-        with: { project: inspec }
       - name: Test
         run: make test
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/oracle-datascience-notebook.yml
+++ b/.github/workflows/oracle-datascience-notebook.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Build
         run: make build
         working-directory: ${{env.working-directory}}
-      - name: Install Inspec
-        uses: actionshub/chef-install@1.1.0
-        with: { project: inspec }
       - name: Test
         run: make test
         working-directory: ${{env.working-directory}}

--- a/allspark-notebook/Makefile
+++ b/allspark-notebook/Makefile
@@ -11,7 +11,7 @@ build:
 test:
 	docker-compose --project-name ${PROJECT_NAME} down
 	docker-compose --project-name ${PROJECT_NAME} up -d
-	inspec exec tests -t docker://${PROJECT_NAME}_test_1
+	docker-compose run --rm inspec exec tests -t docker://${PROJECT_NAME}_test_1
 	docker-compose stop
 
 enter:

--- a/allspark-notebook/docker-compose.yml
+++ b/allspark-notebook/docker-compose.yml
@@ -3,4 +3,15 @@ version: "3.7"
 
 services:
   test:
-    image: mojanalytics/allspark-notebook:latest
+    image: mojanalytics/allspark-notebook:${BUILD_TAG:-latest}
+    command:
+      - "/usr/local/bin/start-notebook.sh"
+      - "--NotebookApp.token=''"
+    ports: [8888:8888]
+    environment: [JUPYTER_ENABLE_LAB=true]
+  inspec:
+    image: chef/inspec:current
+    environment: [CHEF_LICENSE=accept-no-persist]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./tests:/share/tests

--- a/datascience-notebook/Makefile
+++ b/datascience-notebook/Makefile
@@ -11,7 +11,7 @@ build:
 test:
 	docker-compose --project-name ${PROJECT_NAME} down
 	docker-compose --project-name ${PROJECT_NAME} up -d
-	inspec exec tests -t docker://${PROJECT_NAME}_test_1
+	docker-compose run --rm inspec exec tests -t docker://${PROJECT_NAME}_test_1
 	docker-compose stop
 
 enter:

--- a/datascience-notebook/docker-compose.yml
+++ b/datascience-notebook/docker-compose.yml
@@ -3,12 +3,15 @@ version: "3.7"
 
 services:
   test:
-    image: mojanalytics/datascience-notebook:latest
-    # image: quay.io/mojanalytics/datascience-notebook:v0.6.9
+    image: mojanalytics/datascience-notebook:${BUILD_TAG:-latest}
     command:
       - "/usr/local/bin/start-notebook.sh"
       - "--NotebookApp.token=''"
-    ports:
-      - 8888:8888
-    environment:
-      - JUPYTER_ENABLE_LAB=true
+    ports: [8888:8888]
+    environment: [JUPYTER_ENABLE_LAB=true]
+  inspec:
+    image: chef/inspec:current
+    environment: [CHEF_LICENSE=accept-no-persist]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./tests:/share/tests

--- a/datascience-notebook/tests/controls/conda_spec.rb
+++ b/datascience-notebook/tests/controls/conda_spec.rb
@@ -12,4 +12,3 @@ control 'Conda available' do
     its('stdout') { should match /conda/ }
   end
 end
-

--- a/oracle-datascience-notebook/Makefile
+++ b/oracle-datascience-notebook/Makefile
@@ -11,7 +11,7 @@ build:
 test:
 	docker-compose --project-name ${PROJECT_NAME} down
 	docker-compose --project-name ${PROJECT_NAME} up -d
-	inspec exec tests -t docker://${PROJECT_NAME}_test_1
+	docker-compose run --rm inspec exec tests -t docker://${PROJECT_NAME}_test_1
 	docker-compose stop
 
 enter:

--- a/oracle-datascience-notebook/docker-compose.yml
+++ b/oracle-datascience-notebook/docker-compose.yml
@@ -3,4 +3,15 @@ version: "3.7"
 
 services:
   test:
-    image: mojanalytics/oracle-datascience-notebook:latest
+    image: mojanalytics/oracle-datascience-notebook:${BUILD_TAG:-latest}
+    command:
+      - "/usr/local/bin/start-notebook.sh"
+      - "--NotebookApp.token=''"
+    ports: [8888:8888]
+    environment: [JUPYTER_ENABLE_LAB=true]
+  inspec:
+    image: chef/inspec:current
+    environment: [CHEF_LICENSE=accept-no-persist]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./tests:/share/tests


### PR DESCRIPTION
InSpec is now using the InSpec container directly so we no longer need
to install it as part of the pipeline