### PR TITLE
allspark: Bumped BASE image to get newer version of JupyterLab

### DIFF
--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -29,4 +29,4 @@ RUN chown -R "${NB_UID}" /opt/conda \
     && usermod -u "${NB_UID}" "${NB_USER}"
 
 RUN usermod -a -G "staff,users" "${NB_USER}" \
-    && update-alternatives --set editor /bin/nano
+    && update-alternatives --set editor /bin/nano-tiny


### PR DESCRIPTION
When I tried to run the old image I realised that the version of JupyterLab
was `0.34.0` which is 2 years old, not only ancient but also older than the
version in "vanilla" image used by most our users at the moment.

New base image comes with JupyterLab `2.2.9` and Python `3.8.6`.

As always with these big bumps, hard to say what else changed and if
it breaks anything else, so it will need more testing.

JupyterLab changelog: https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html