### PR TITLE
🛠️ update JupyterLab version

### DIFF
--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -31,5 +31,4 @@ RUN apt-get update --yes \
     && nbstripout --install --system \
     && update-alternatives --set editor /bin/nano-tiny
 
-COPY files/add-user-to-group.sh /usr/local/bin/before-notebook.d/add-user-to-group.sh
-COPY files/hdfs-site.xml /usr/local/spark/conf/hdfs-site.xml
+USER $NB_UID

--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.4.4
-FROM quay.io/jupyter/all-spark-notebook@sha256:1f1a52d3154254fe445d9c860195cd3f502f484b33078513907b003db307e43e
+# lab-4.0.7
+FROM quay.io/jupyter/all-spark-notebook@sha256:1bc3d7caf44c0c7ac2a4704fbe2d27e3f6c24918298921286e352a2e06cfa53e
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -33,3 +33,5 @@ RUN apt-get update --yes \
 
 COPY files/add-user-to-group.sh /usr/local/bin/before-notebook.d/add-user-to-group.sh
 COPY files/hdfs-site.xml /usr/local/spark/conf/hdfs-site.xml
+
+USER $NB_UID

--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.1.0
-FROM quay.io/jupyter/all-spark-notebook@sha256:8f0761924bc732c0c0db47eea6d2d06f674d79e487da2a134812408d4e5e2de5
+# lab-4.4.5
+FROM quay.io/jupyter/all-spark-notebook@sha256:ce1206118af3e311d7770ae0a50f1d70445937c66867b7eacdac3d8a44ca6922
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.0.7
-FROM quay.io/jupyter/all-spark-notebook@sha256:1bc3d7caf44c0c7ac2a4704fbe2d27e3f6c24918298921286e352a2e06cfa53e
+# lab-4.1.0
+FROM quay.io/jupyter/all-spark-notebook@sha256:8f0761924bc732c0c0db47eea6d2d06f674d79e487da2a134812408d4e5e2de5
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -33,5 +33,3 @@ RUN apt-get update --yes \
 
 COPY files/add-user-to-group.sh /usr/local/bin/before-notebook.d/add-user-to-group.sh
 COPY files/hdfs-site.xml /usr/local/spark/conf/hdfs-site.xml
-
-USER $NB_UID

--- a/allspark-notebook/Dockerfile
+++ b/allspark-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.0.11
-FROM quay.io/jupyter/all-spark-notebook@sha256:a63b0faed54bc21d17a4691d8fae177dd95236e0adddbd9d43ee448dc2d5ba1e
+# lab-4.4.4
+FROM quay.io/jupyter/all-spark-notebook@sha256:1f1a52d3154254fe445d9c860195cd3f502f484b33078513907b003db307e43e
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/allspark-notebook/Makefile
+++ b/allspark-notebook/Makefile
@@ -7,7 +7,7 @@ TRIVY_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-db:2
 TRIVY_JAVA_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-java-db:1
 
 run: build
-	docker run --rm -it --publish 8080:8080 $(IMAGE_NAME):$(IMAGE_TAG)
+	docker run --rm -it --publish 8888:8888 $(IMAGE_NAME):$(IMAGE_TAG)
 
 test: build
 	container-structure-test test --platform linux/amd64 --config test/container-structure-test.yml --image $(IMAGE_NAME):$(IMAGE_TAG)

--- a/allspark-notebook/Makefile
+++ b/allspark-notebook/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build scan test run
+
+IMAGE_NAME ?= ghcr.io/ministryofjustice/analytical-platform-allspark-notebook
+IMAGE_TAG  ?= local
+
+TRIVY_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-db:2
+TRIVY_JAVA_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-java-db:1
+
+run: build
+	docker run --rm -it --publish 8080:8080 $(IMAGE_NAME):$(IMAGE_TAG)
+
+test: build
+	container-structure-test test --platform linux/amd64 --config test/container-structure-test.yml --image $(IMAGE_NAME):$(IMAGE_TAG)
+
+scan: build
+	trivy image --platform linux/amd64 --severity HIGH,CRITICAL $(IMAGE_NAME):$(IMAGE_TAG)
+
+build:
+	@ARCH=`uname --machine`; \
+	case $$ARCH in \
+	aarch64 | arm64) \
+		echo "Building on $$ARCH architecture"; \
+		docker build --platform linux/amd64 --file Dockerfile --tag $(IMAGE_NAME):$(IMAGE_TAG) . ;; \
+	*) \
+		echo "Building on $$ARCH architecture"; \
+		docker build --file Dockerfile --tag $(IMAGE_NAME):$(IMAGE_TAG) . ;; \
+	esac

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -32,3 +32,5 @@ RUN apt-get update --yes \
          nbstripout \
     && nbstripout --install --system \
     && update-alternatives --set editor /bin/nano-tiny
+
+USER $NB_UID

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.1.0
-FROM quay.io/jupyter/datascience-notebook@sha256:9d04346458fb7b3222a1fabed8d5f653cbab8b7ea03cb0fcc5d5422748e551c1
+# lab-4.4.5
+FROM quay.io/jupyter/datascience-notebook@sha256:c8a31a629cd58bc9d418df8057b41fa7f4e630edfbcb16f5adb2b0ed99271576
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.0.11
-FROM quay.io/jupyter/datascience-notebook@sha256:76148e403aa44017f59b1dd0861d91daae800c7f86e9f39138b9d2703b885082
+# lab-4.4.4
+FROM quay.io/jupyter/datascience-notebook@sha256:20be99bdec2d0ae0c17845e1805a152e3d6629a38aee5a6bf1348bfcf2c12231
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.0.7
-FROM quay.io/jupyter/datascience-notebook@sha256:40856f68fdda72f664944cb334f29a720d8b93fe05afb1b8d535e027488e7724
+# lab-4.1.0
+FROM quay.io/jupyter/datascience-notebook@sha256:9d04346458fb7b3222a1fabed8d5f653cbab8b7ea03cb0fcc5d5422748e551c1
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -1,5 +1,5 @@
-# lab-4.4.4
-FROM quay.io/jupyter/datascience-notebook@sha256:20be99bdec2d0ae0c17845e1805a152e3d6629a38aee5a6bf1348bfcf2c12231
+# lab-4.0.7
+FROM quay.io/jupyter/datascience-notebook@sha256:40856f68fdda72f664944cb334f29a720d8b93fe05afb1b8d535e027488e7724
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/datascience-notebook/Makefile
+++ b/datascience-notebook/Makefile
@@ -16,7 +16,7 @@ scan: build
 	trivy image --platform linux/amd64 --severity HIGH,CRITICAL $(IMAGE_NAME):$(IMAGE_TAG)
 
 build:
-	@ARCH=`uname --machine`; \
+	@ARCH=`uname -m`; \
 	case $$ARCH in \
 	aarch64 | arm64) \
 		echo "Building on $$ARCH architecture"; \

--- a/datascience-notebook/Makefile
+++ b/datascience-notebook/Makefile
@@ -7,7 +7,7 @@ TRIVY_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-db:2
 TRIVY_JAVA_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-java-db:1
 
 run: build
-	docker run --rm -it --publish 8080:8080 $(IMAGE_NAME):$(IMAGE_TAG)
+	docker run --rm -it --publish 8888:8888 $(IMAGE_NAME):$(IMAGE_TAG)
 
 test: build
 	container-structure-test test --platform linux/amd64 --config test/container-structure-test.yml --image $(IMAGE_NAME):$(IMAGE_TAG)

--- a/datascience-notebook/Makefile
+++ b/datascience-notebook/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build scan test run
+
+IMAGE_NAME ?= ghcr.io/ministryofjustice/analytical-platform-datascience-notebook
+IMAGE_TAG  ?= local
+
+TRIVY_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-db:2
+TRIVY_JAVA_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-java-db:1
+
+run: build
+	docker run --rm -it --publish 8080:8080 $(IMAGE_NAME):$(IMAGE_TAG)
+
+test: build
+	container-structure-test test --platform linux/amd64 --config test/container-structure-test.yml --image $(IMAGE_NAME):$(IMAGE_TAG)
+
+scan: build
+	trivy image --platform linux/amd64 --severity HIGH,CRITICAL $(IMAGE_NAME):$(IMAGE_TAG)
+
+build:
+	@ARCH=`uname --machine`; \
+	case $$ARCH in \
+	aarch64 | arm64) \
+		echo "Building on $$ARCH architecture"; \
+		docker build --platform linux/amd64 --file Dockerfile --tag $(IMAGE_NAME):$(IMAGE_TAG) . ;; \
+	*) \
+		echo "Building on $$ARCH architecture"; \
+		docker build --file Dockerfile --tag $(IMAGE_NAME):$(IMAGE_TAG) . ;; \
+	esac

--- a/datascience-notebook/test/container-structure-test.yml
+++ b/datascience-notebook/test/container-structure-test.yml
@@ -27,7 +27,7 @@ commandTests:
   - name: "juptyer-lab"
     command: "jupyter-lab"
     args: ["--version"]
-    expectedOutput: ["4.4.4"]
+    expectedOutput: ["4.1.0"]
 
   - name: "nano"
     command: "nano"

--- a/datascience-notebook/test/container-structure-test.yml
+++ b/datascience-notebook/test/container-structure-test.yml
@@ -27,7 +27,7 @@ commandTests:
   - name: "juptyer-lab"
     command: "jupyter-lab"
     args: ["--version"]
-    expectedOutput: ["4.0.11"]
+    expectedOutput: ["4.4.4"]
 
   - name: "nano"
     command: "nano"

--- a/datascience-notebook/test/container-structure-test.yml
+++ b/datascience-notebook/test/container-structure-test.yml
@@ -27,7 +27,7 @@ commandTests:
   - name: "juptyer-lab"
     command: "jupyter-lab"
     args: ["--version"]
-    expectedOutput: ["4.1.0"]
+    expectedOutput: ["4.4.5"]
 
   - name: "nano"
     command: "nano"


### PR DESCRIPTION
This pull request:

- contributes to this issue: https://github.com/ministryofjustice/analytical-platform/issues/7872
- updates base image versions for jupyterlab
- adds a Makefile for each flavour of jupyterlab

Both container images have been spun up locally and were able to produce basic outputs using pandas and spark dataframes.

Versions are being updated to the following:
- Python: `3.12.11`
- JupyterLab: `4.4.5`
- Spark: `4.0.0`

Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>